### PR TITLE
Force wait and build of databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     env_file:
       - test.env
     command: ["./script/start.sh", "development"]
+    depends_on:
+      - setup_dbs
 
   test:
     <<: *build_test
@@ -53,7 +55,8 @@ services:
       RAILS_ENV: test
     env_file:
       - test.env
-    command: ["/tmp/wait-for-it.sh", "db:3306", "solr:8983", "--", "rake", "db:setup"]
+    command: >
+      bash -c "sleep 5; rake db:setup"
     depends_on:
       - db
       - solr
@@ -62,7 +65,8 @@ services:
     <<: *build_test
     env_file:
       - test.env
-    command: ["/tmp/wait-for-it.sh", "db:3306", "solr:8983", "--", "rake", "db:setup"]
+    command: >
+      bash -c "sleep 5; rake db:setup"
     depends_on:
       - db
       - solr


### PR DESCRIPTION
@ericgriffis I find this is the only way I can automate the building of the databases when bringing up dev or test containers. The `depends_on` was just an omission I believe and is necessary. The alternative command syntax I don't know why it works and the `[""]` doesn't but it's all I've been able to get work.