### PR TITLE
Remove login link and login/logout routes

### DIFF
--- a/app/views/common/_breadcrumbs.html.erb
+++ b/app/views/common/_breadcrumbs.html.erb
@@ -1,3 +1,9 @@
+<!--
+    Overrides https://github.com/NYULibraries/nyulibraries_templates/blob/97161f374723442bf8e5c58fa127b8f570f50199/app/templates/nyulibraries_templates/common/_breadcrumbs.html.erb
+    See:
+        "Remove Login from Special Collections dev only"
+        https://nyu-lib.monday.com/boards/765008773/pulses/3641755097
+-->
 <ol class="nyu-breadcrumbs">
   <% breadcrumbs.each do |breadcrumb| %>
     <li><%= breadcrumb %></li>

--- a/app/views/common/_breadcrumbs.html.erb
+++ b/app/views/common/_breadcrumbs.html.erb
@@ -1,0 +1,5 @@
+<ol class="nyu-breadcrumbs">
+  <% breadcrumbs.each do |breadcrumb| %>
+    <li><%= breadcrumb %></li>
+  <% end %>
+</ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,8 +43,15 @@ Findingaids::Application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do
-    get 'logout', to: 'devise/sessions#destroy', as: :logout
-    get 'login', to: redirect { |params, request| "#{Rails.application.config.relative_url_root}/users/auth/nyulibraries?#{request.query_string}" }, as: :login
+    # See:
+    #   Remove Login from Special Collections dev only
+    #   https://nyu-lib.monday.com/boards/765008773/pulses/3641755097
+    #
+    # Removing `devise_for :users, ...` and this `devise_scope` entirely seem to
+    # break the application, so for now just commenting out these routes.
+    #
+    # get 'logout', to: 'devise/sessions#destroy', as: :logout
+    # get 'login', to: redirect { |params, request| "#{Rails.application.config.relative_url_root}/users/auth/nyulibraries?#{request.query_string}" }, as: :login
   end
 
   get 'healthcheck' => 'help#healthcheck'


### PR DESCRIPTION
monday.com: https://nyu-lib.monday.com/boards/765008773/pulses/3641755097

* Override [nyulibraries\_templates/app/templates/nyulibraries\_templates/common/\_breadcrumbs\.html\.erb](https://github.com/NYULibraries/nyulibraries_templates/blob/97161f374723442bf8e5c58fa127b8f570f50199/app/templates/nyulibraries_templates/common/_breadcrumbs.html.erb) and remove the login link
* Disable the /login and /logout routes