### PR TITLE
feature/add support for 2022 migration yml with override

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -67,3 +67,8 @@ The description of EAD in Solr proves to require more configuration so we use [a
   ```
 
 9. Visiting `http://localhost:3000` should present you with the development application.
+
+## Note
+You can use the `FINDINGAIDS_2022_MIGRATION` environment variable to control application behavior.  
+If `ENV['FINDINGAIDS_2022_MIGRATION']` is `nil`, then the application will operate in legacy mode.  
+If `ENV['FINDINGAIDS_2022_MIGRATION']` is not `nil`, then the application will operate in the `FINDINGAIDS_2022_MIGRATION` mode.  

--- a/config/repositories-findingaids_2022_migration.yml
+++ b/config/repositories-findingaids_2022_migration.yml
@@ -24,7 +24,7 @@ Catalog:
       display: 'Center for Brooklyn History'
       url_safe_display: 'Center for Brooklyn History'
       url: "brooklynhistory"
-      admin_code: "bhs"
+      admin_code: "cbh"
     poly:
       display: 'Poly Archives'
       url_safe_display: 'Poly Archives'

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -50,8 +50,11 @@ Catalog:
       url_safe_display: 'Villa La Pietra'
       url: "vlp"
       admin_code: "vlp"
-CatalogOverrideV2:
+CatalogOverride:
   repositories:
     brooklynhistory:
+      display: 'Center for Brooklyn History'
+      url_safe_display: 'Center for Brooklyn History'
+      url: "brooklynhistory"
       admin_code: "cbh"
   

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -50,3 +50,8 @@ Catalog:
       url_safe_display: 'Villa La Pietra'
       url: "vlp"
       admin_code: "vlp"
+CatalogOverrideV2:
+  repositories:
+    brooklynhistory:
+      admin_code: "cbh"
+  

--- a/lib/findingaids/repositories.rb
+++ b/lib/findingaids/repositories.rb
@@ -3,23 +3,9 @@ module Findingaids
     include Enumerable
 
     def self.repositories
-      return @repositories if @repositories
+      repositories_yaml_file = ENV['FINDINGAIDS_2022_MIGRATION'] ? "repositories-findingaids_2022_migration.yml" : "repositories.yml"
 
-      # This code allows the values from the YAML file to be overridden based on
-      # whether or not the FINDINGAIDS_2022_MIGRATION environment variable is set
-
-      # load repositories.yml file
-      yaml_contents = YAML.load_file( File.join(Rails.root, "config", "repositories.yml") )
-
-      # extract legacy repositories
-      @repositories = yaml_contents["Catalog"]["repositories"]
-
-      # override repositories if needed
-      if ENV['FINDINGAIDS_2022_MIGRATION']
-        @repositories.merge!(yaml_contents["CatalogOverride"]["repositories"])
-      end
-
-      @repositories
+      @repositories ||= YAML.load_file( File.join(Rails.root, "config", repositories_yaml_file) )["Catalog"]["repositories"]
     end
 
     extend Forwardable

--- a/lib/findingaids/repositories.rb
+++ b/lib/findingaids/repositories.rb
@@ -3,7 +3,23 @@ module Findingaids
     include Enumerable
 
     def self.repositories
-      @repositories ||= YAML.load_file( File.join(Rails.root, "config", "repositories.yml") )["Catalog"]["repositories"]
+      return @repositories if @repositories
+
+      # This code allows the values from the YAML file to be overridden based on
+      # whether or not the FINDINGAIDS_2022_MIGRATION environment variable is set
+
+      # load repositories.yml file
+      yaml_contents = YAML.load_file( File.join(Rails.root, "config", "repositories.yml") )
+
+      # extract legacy repositories
+      @repositories = yaml_contents["Catalog"]["repositories"]
+
+      # override repositories if needed
+      if ENV['FINDINGAIDS_2022_MIGRATION']
+        @repositories.merge!(yaml_contents["CatalogOverride"]["repositories"])
+      end
+
+      @repositories
     end
 
     extend Forwardable

--- a/lib/findingaids/repositories.rb
+++ b/lib/findingaids/repositories.rb
@@ -3,9 +3,10 @@ module Findingaids
     include Enumerable
 
     def self.repositories
-      repositories_yaml_file = ENV['FINDINGAIDS_2022_MIGRATION'] ? "repositories-findingaids_2022_migration.yml" : "repositories.yml"
-
-      @repositories ||= YAML.load_file( File.join(Rails.root, "config", repositories_yaml_file) )["Catalog"]["repositories"]
+      @repositories ||= begin
+                          repositories_yaml_file = ENV['FINDINGAIDS_2022_MIGRATION'] ? "repositories-findingaids_2022_migration.yml" : "repositories.yml"
+                          YAML.load_file( File.join(Rails.root, "config", repositories_yaml_file) )["Catalog"]["repositories"]
+                        end
     end
 
     extend Forwardable

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -144,11 +144,19 @@ describe ApplicationHelper do
     describe "#repositories" do
       subject(:repositories) { Findingaids::Repositories.repositories }
 
-      context "when repository is BHS" do
+      context "when repository is BHS, admin_code should have changed" do
         subject(:repository) { repositories['brooklynhistory'] }
         it { expect(repository['display']).to eql("Center for Brooklyn History") }
         it { expect(repository['url']).to eql("brooklynhistory") }
         it { expect(repository['admin_code']).to eql("cbh") }
+      end
+
+      context "when repository is Tamiment, nothing should have changed" do
+        subject(:repository) { repositories['tamiment'] }
+        it { expect(repository['display']).to eql("Tamiment Library & Wagner Labor Archives") }
+        it { expect(repository['url']).to eql("tamiment") }
+        it { expect(repository["url_safe_display"]).to eql("Tamiment Library %26 Wagner Labor Archives")
+        it { expect(repository['admin_code']).to eql("tamwag") }
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -153,7 +153,7 @@ describe ApplicationHelper do
     describe "#repositories" do
       subject(:repositories) { Findingaids::Repositories.repositories }
 
-      context "when repository is BHS, admin_code should have changed" do
+      context "when repository is 'brooklynhistory', admin_code should have changed" do
         subject(:repository) { repositories['brooklynhistory'] }
         it { expect(repository['display']).to eql("Center for Brooklyn History") }
         it { expect(repository['url_safe_display']).to eql("Center for Brooklyn History") }
@@ -161,7 +161,7 @@ describe ApplicationHelper do
         it { expect(repository['admin_code']).to eql("cbh") }
       end
 
-      context "when repository is Tamiment, nothing should have changed" do
+      context "when repository is 'tamiment', nothing should have changed" do
         subject(:repository) { repositories['tamiment'] }
         it { expect(repository['display']).to eql("Tamiment Library & Wagner Labor Archives") }
         it { expect(repository['url']).to eql("tamiment") }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,124 +2,154 @@ require 'rails_helper'
 
 describe ApplicationHelper do
 
-  let(:repository) {"The Fales Library & Special Collections"}
-  let(:params) {{:repository => repository}}
-  let!(:repositories) { Findingaids::Repositories.repositories }
+  context "when in the legacy configuration" do
+    let(:repository) {"The Fales Library & Special Collections"}
+    let(:params) {{:repository => repository}}
+    let!(:repositories) { Findingaids::Repositories.repositories }
 
-  before do
-    allow(helper).to receive(:repositories).and_return repositories
-    allow(helper).to receive(:params).and_return params
-  end
-
-  describe "#current_repository" do
-    subject { helper.current_repository.first }
-    it { is_expected.to eql "fales" }
-  end
-
-  describe "#searching?" do
-    subject { helper.searching? }
-    context "when we ARE NOT actively searching the index" do
-      it { is_expected.to be false }
+    before do
+      allow(helper).to receive(:repositories).and_return repositories
+      allow(helper).to receive(:params).and_return params
     end
-    context "when we ARE actively searching the index" do
-      let(:params) {{:q => "query"}}
-      it { is_expected.to be true }
-    end
-  end
 
-  describe "#current_repository_url" do
-    subject { helper.current_repository_url }
-    context "when the repository is The Fales Library & Special Collections" do
+    describe "#current_repository" do
+      subject { helper.current_repository.first }
       it { is_expected.to eql "fales" }
     end
-    context "when the repository is Tamiment Library & Wagner Labor Archives" do
-      let(:repository) { "Tamiment Library & Wagner Labor Archives" }
-      it { is_expected.to eql "tamiment" }
+
+    describe "#searching?" do
+      subject { helper.searching? }
+      context "when we ARE NOT actively searching the index" do
+        it { is_expected.to be false }
+      end
+      context "when we ARE actively searching the index" do
+        let(:params) {{:q => "query"}}
+        it { is_expected.to be true }
+      end
+    end
+
+    describe "#current_repository_url" do
+      subject { helper.current_repository_url }
+      context "when the repository is The Fales Library & Special Collections" do
+        it { is_expected.to eql "fales" }
+      end
+      context "when the repository is Tamiment Library & Wagner Labor Archives" do
+        let(:repository) { "Tamiment Library & Wagner Labor Archives" }
+        it { is_expected.to eql "tamiment" }
+      end
+    end
+
+    describe "#current_repository_home_text?" do
+      subject { helper.current_repository_home_text? }
+      context "when current repository has home text" do
+        it { is_expected.to_not be_empty }
+      end
+      context "when current repository doesn't exist" do
+        let(:repository) { "The Nothing Library" }
+        it { is_expected.to be false }
+      end
+    end
+
+    describe "#maintenance_mode?" do
+      subject { helper.maintenance_mode? }
+      it { is_expected.to_not be_nil }
+    end
+
+    describe "#repositories" do
+      subject(:repositories) { helper.repositories }
+
+      context "when repository is Fales" do
+        subject(:repository) { repositories['fales'] }
+        it { expect(repository['display']).to eql("The Fales Library & Special Collections") }
+        it { expect(repository['url']).to eql("fales") }
+        it { expect(repository['admin_code']).to eql("fales") }
+      end
+
+      context "when repository is Tamiment " do
+        subject(:repository) { repositories['tamiment'] }
+        it { expect(repository['display']).to eql("Tamiment Library & Wagner Labor Archives") }
+        it { expect(repository['url']).to eql("tamiment") }
+        it { expect(repository['admin_code']).to eql("tamwag") }
+      end
+
+      context "when repository is NYU Archives " do
+        subject(:repository) { repositories['universityarchives'] }
+        it { expect(repository['display']).to eql("New York University Archives") }
+        it { expect(repository['url']).to eql("universityarchives") }
+        it { expect(repository['admin_code']).to eql("archives") }
+      end
+
+      context "when repository is NYHS" do
+        subject(:repository) { repositories['nyhistory'] }
+        it { expect(repository['display']).to eql("New-York Historical Society") }
+        it { expect(repository['url']).to eql("nyhistory") }
+        it { expect(repository['admin_code']).to eql("nyhs") }
+      end
+
+      context "when repository is BHS" do
+        subject(:repository) { repositories['brooklynhistory'] }
+        it { expect(repository['display']).to eql("Center for Brooklyn History") }
+        it { expect(repository['url']).to eql("brooklynhistory") }
+        it { expect(repository['admin_code']).to eql("bhs") }
+      end
+
+      context "when repository is Poly Archives" do
+        subject(:repository) { repositories['poly'] }
+        it { expect(repository['display']).to eql("Poly Archives") }
+        it { expect(repository['url']).to eql("poly") }
+        it { expect(repository['admin_code']).to eql("poly") }
+      end
+
+      context "when repository is RISM" do
+        subject(:repository) { repositories['rism'] }
+        it { expect(repository['display']).to eql("Research Institute for the Study of Man") }
+        it { expect(repository['url']).to eql("rism") }
+        it { expect(repository['admin_code']).to eql("rism") }
+      end
+
+      context "when repository is NYUAD" do
+        subject(:repository) { repositories['nyuad'] }
+        it { expect(repository['display']).to eql("NYU Abu Dhabi Archives and Special Collections") }
+        it { expect(repository['url']).to eql("nyuad") }
+        it { expect(repository['admin_code']).to eql("nyuad") }
+      end
+
+      context "when repository is VLP" do
+        subject(:repository) { repositories['vlp'] }
+        it { expect(repository['display']).to eql("Villa La Pietra") }
+        it { expect(repository['url']).to eql("vlp") }
+        it { expect(repository['admin_code']).to eql("vlp") }
+      end
+
     end
   end
 
-  describe "#current_repository_home_text?" do
-    subject { helper.current_repository_home_text? }
-    context "when current repository has home text" do
-      it { is_expected.to_not be_empty }
+  context "when in the FINDINGAIDS_2022_MIGRATION configuration" do
+    before do
+      # force class reload to ensure that the
+      #   Findingaids::Repositories @repositories class instance
+      #   variable is reinitialized
+      # ref: https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#reloading-and-stale-objects
+      #
+      ENV['FINDINGAIDS_2022_MIGRATION'] = "1"
+      Findingaids.send(:remove_const, "Repositories")
+      load Rails.root.join('lib', 'findingaids', 'repositories.rb')
     end
-    context "when current repository doesn't exist" do
-      let(:repository) { "The Nothing Library" }
-      it { is_expected.to be false }
+    after do
+      ENV['FINDINGAIDS_2022_MIGRATION'] = nil
+      Findingaids.send(:remove_const, "Repositories")
+      load Rails.root.join('lib', 'findingaids', 'repositories.rb')
+    end
+
+    describe "#repositories" do
+      subject(:repositories) { Findingaids::Repositories.repositories }
+
+      context "when repository is BHS" do
+        subject(:repository) { repositories['brooklynhistory'] }
+        it { expect(repository['display']).to eql("Center for Brooklyn History") }
+        it { expect(repository['url']).to eql("brooklynhistory") }
+        it { expect(repository['admin_code']).to eql("cbh") }
+      end
     end
   end
-
-  describe "#maintenance_mode?" do
-    subject { helper.maintenance_mode? }
-    it { is_expected.to_not be_nil }
-  end
-
-  describe "#repositories" do
-    subject(:repositories) { helper.repositories }
-
-    context "when repository is Fales" do
-      subject(:repository) { repositories['fales'] }
-      it { expect(repository['display']).to eql("The Fales Library & Special Collections") }
-      it { expect(repository['url']).to eql("fales") }
-      it { expect(repository['admin_code']).to eql("fales") }
-    end
-
-    context "when repository is Tamiment " do
-      subject(:repository) { repositories['tamiment'] }
-      it { expect(repository['display']).to eql("Tamiment Library & Wagner Labor Archives") }
-      it { expect(repository['url']).to eql("tamiment") }
-      it { expect(repository['admin_code']).to eql("tamwag") }
-    end
-
-    context "when repository is NYU Archives " do
-      subject(:repository) { repositories['universityarchives'] }
-      it { expect(repository['display']).to eql("New York University Archives") }
-      it { expect(repository['url']).to eql("universityarchives") }
-      it { expect(repository['admin_code']).to eql("archives") }
-    end
-
-    context "when repository is NYHS" do
-      subject(:repository) { repositories['nyhistory'] }
-      it { expect(repository['display']).to eql("New-York Historical Society") }
-      it { expect(repository['url']).to eql("nyhistory") }
-      it { expect(repository['admin_code']).to eql("nyhs") }
-    end
-
-    context "when repository is BHS" do
-      subject(:repository) { repositories['brooklynhistory'] }
-      it { expect(repository['display']).to eql("Center for Brooklyn History") }
-      it { expect(repository['url']).to eql("brooklynhistory") }
-      it { expect(repository['admin_code']).to eql("bhs") }
-    end
-
-    context "when repository is Poly Archives" do
-      subject(:repository) { repositories['poly'] }
-      it { expect(repository['display']).to eql("Poly Archives") }
-      it { expect(repository['url']).to eql("poly") }
-      it { expect(repository['admin_code']).to eql("poly") }
-    end
-
-    context "when repository is RISM" do
-      subject(:repository) { repositories['rism'] }
-      it { expect(repository['display']).to eql("Research Institute for the Study of Man") }
-      it { expect(repository['url']).to eql("rism") }
-      it { expect(repository['admin_code']).to eql("rism") }
-    end
-
-    context "when repository is NYUAD" do
-      subject(:repository) { repositories['nyuad'] }
-      it { expect(repository['display']).to eql("NYU Abu Dhabi Archives and Special Collections") }
-      it { expect(repository['url']).to eql("nyuad") }
-      it { expect(repository['admin_code']).to eql("nyuad") }
-    end
-
-    context "when repository is VLP" do
-      subject(:repository) { repositories['vlp'] }
-      it { expect(repository['display']).to eql("Villa La Pietra") }
-      it { expect(repository['url']).to eql("vlp") }
-      it { expect(repository['admin_code']).to eql("vlp") }
-    end
-
-  end
-
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -156,6 +156,7 @@ describe ApplicationHelper do
       context "when repository is BHS, admin_code should have changed" do
         subject(:repository) { repositories['brooklynhistory'] }
         it { expect(repository['display']).to eql("Center for Brooklyn History") }
+        it { expect(repository['url_safe_display']).to eql("Center for Brooklyn History") }
         it { expect(repository['url']).to eql("brooklynhistory") }
         it { expect(repository['admin_code']).to eql("cbh") }
       end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -61,6 +61,7 @@ describe ApplicationHelper do
       context "when repository is Fales" do
         subject(:repository) { repositories['fales'] }
         it { expect(repository['display']).to eql("The Fales Library & Special Collections") }
+        it { expect(repository['url_safe_display']).to eql("The Fales Library %26 Special Collections") }
         it { expect(repository['url']).to eql("fales") }
         it { expect(repository['admin_code']).to eql("fales") }
       end
@@ -68,6 +69,7 @@ describe ApplicationHelper do
       context "when repository is Tamiment " do
         subject(:repository) { repositories['tamiment'] }
         it { expect(repository['display']).to eql("Tamiment Library & Wagner Labor Archives") }
+        it { expect(repository['url_safe_display']).to eql("Tamiment Library %26 Wagner Labor Archives") }
         it { expect(repository['url']).to eql("tamiment") }
         it { expect(repository['admin_code']).to eql("tamwag") }
       end
@@ -75,6 +77,7 @@ describe ApplicationHelper do
       context "when repository is NYU Archives " do
         subject(:repository) { repositories['universityarchives'] }
         it { expect(repository['display']).to eql("New York University Archives") }
+        it { expect(repository['url_safe_display']).to eql("New York University Archives") }
         it { expect(repository['url']).to eql("universityarchives") }
         it { expect(repository['admin_code']).to eql("archives") }
       end
@@ -82,6 +85,7 @@ describe ApplicationHelper do
       context "when repository is NYHS" do
         subject(:repository) { repositories['nyhistory'] }
         it { expect(repository['display']).to eql("New-York Historical Society") }
+        it { expect(repository['url_safe_display']).to eql("New-York Historical Society") }
         it { expect(repository['url']).to eql("nyhistory") }
         it { expect(repository['admin_code']).to eql("nyhs") }
       end
@@ -89,6 +93,7 @@ describe ApplicationHelper do
       context "when repository is BHS" do
         subject(:repository) { repositories['brooklynhistory'] }
         it { expect(repository['display']).to eql("Center for Brooklyn History") }
+        it { expect(repository['url_safe_display']).to eql("Center for Brooklyn History") }
         it { expect(repository['url']).to eql("brooklynhistory") }
         it { expect(repository['admin_code']).to eql("bhs") }
       end
@@ -96,6 +101,7 @@ describe ApplicationHelper do
       context "when repository is Poly Archives" do
         subject(:repository) { repositories['poly'] }
         it { expect(repository['display']).to eql("Poly Archives") }
+        it { expect(repository['url_safe_display']).to eql("Poly Archives") }
         it { expect(repository['url']).to eql("poly") }
         it { expect(repository['admin_code']).to eql("poly") }
       end
@@ -103,6 +109,7 @@ describe ApplicationHelper do
       context "when repository is RISM" do
         subject(:repository) { repositories['rism'] }
         it { expect(repository['display']).to eql("Research Institute for the Study of Man") }
+        it { expect(repository['url_safe_display']).to eql("Research Institute for the Study of Man") }
         it { expect(repository['url']).to eql("rism") }
         it { expect(repository['admin_code']).to eql("rism") }
       end
@@ -110,6 +117,7 @@ describe ApplicationHelper do
       context "when repository is NYUAD" do
         subject(:repository) { repositories['nyuad'] }
         it { expect(repository['display']).to eql("NYU Abu Dhabi Archives and Special Collections") }
+        it { expect(repository['url_safe_display']).to eql("NYU Abu Dhabi Archives and Special Collections") }
         it { expect(repository['url']).to eql("nyuad") }
         it { expect(repository['admin_code']).to eql("nyuad") }
       end
@@ -117,6 +125,7 @@ describe ApplicationHelper do
       context "when repository is VLP" do
         subject(:repository) { repositories['vlp'] }
         it { expect(repository['display']).to eql("Villa La Pietra") }
+        it { expect(repository['url_safe_display']).to eql("Villa La Pietra") }
         it { expect(repository['url']).to eql("vlp") }
         it { expect(repository['admin_code']).to eql("vlp") }
       end
@@ -155,7 +164,7 @@ describe ApplicationHelper do
         subject(:repository) { repositories['tamiment'] }
         it { expect(repository['display']).to eql("Tamiment Library & Wagner Labor Archives") }
         it { expect(repository['url']).to eql("tamiment") }
-        it { expect(repository["url_safe_display"]).to eql("Tamiment Library %26 Wagner Labor Archives")
+        it { expect(repository["url_safe_display"]).to eql("Tamiment Library %26 Wagner Labor Archives") }
         it { expect(repository['admin_code']).to eql("tamwag") }
       end
     end

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -245,7 +245,7 @@ describe ResultsHelper do
         end
       end
     end
-    context "when in the new FINDINGAIDS_2022_MIGRATION configuration" do
+    context "when in the FINDINGAIDS_2022_MIGRATION configuration" do
       before {
         ENV['FINDINGAIDS_2022_MIGRATION'] = "1"
       }

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -245,7 +245,7 @@ describe ResultsHelper do
         end
       end
     end
-    context "when in the new FADESIGN configuration" do
+    context "when in the new FINDINGAIDS_2022_MIGRATION configuration" do
       before {
         ENV['FINDINGAIDS_2022_MIGRATION'] = "1"
       }


### PR DESCRIPTION
## Overview:

This PR adds support for using different values from `repositories.yml` file based on the presence of the `ENV['FINDINGAIDS_2022_MIGRATION']` variable.

This change is needed because the subdirectory name for the Center for Brooklyn History has changed from `bhs` to `cbh` in the `FINDINGAIDS_2022_MIGRATION` EAD Git repository.