### PR TITLE
Add new archival repository: `arabartarchive`, add check on repository lookup

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -68,7 +68,15 @@ The description of EAD in Solr proves to require more configuration so we use [a
 
 9. Visiting `http://localhost:3000` should present you with the development application.
 
-## Note
-You can use the `FINDINGAIDS_2022_MIGRATION` environment variable to control application behavior.  
-If `ENV['FINDINGAIDS_2022_MIGRATION']` is `nil`, then the application will operate in legacy mode.  
-If `ENV['FINDINGAIDS_2022_MIGRATION']` is not `nil`, then the application will operate in the `FINDINGAIDS_2022_MIGRATION` mode.   
+
+## Developer Notes:
+1. Running the code in V1 (legacy) and V2 (FADESIGFINDINGAIDS_2022_MIGRATION) modes:
+  You can use the `FINDINGAIDS_2022_MIGRATION` environment variable to control application behavior.  
+  If `ENV['FINDINGAIDS_2022_MIGRATION']` is `nil`, then the application will operate in legacy mode.  
+  If `ENV['FINDINGAIDS_2022_MIGRATION']` is not `nil`, then the application will operate in the `FINDINGAIDS_2022_MIGRATION` mode.   
+
+2. Adding a new archival repository
+  To add a new archival repository, e.g., `arabartarchive`, you need to update the following files:
+  a.) the `config/repositories.yml` and `config/repositories-findingaids_2022_migration.yml` files
+  b.) the `config/locales/en.yml` file
+      * The only required key/value pair for the new repository is `url`

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -80,3 +80,4 @@ The description of EAD in Solr proves to require more configuration so we use [a
   a.) the `config/repositories.yml` and `config/repositories-findingaids_2022_migration.yml` files
   b.) the `config/locales/en.yml` file
       * The only required key/value pair for the new repository is `url`
+

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -50,7 +50,15 @@ module ResultsHelper
   end
 
   def render_repository_facet_link(doc)
-    repository_label repositories.find{|key,hash| hash["admin_code"] == doc}[1]["url"]
+    r = repositories.find{|key,hash| hash["admin_code"] == doc}
+
+    if r.nil?
+      "missing repository for: #{doc}"
+    else
+      repository_label r[1]["url"]
+    end
+
+#    repository_label repositories.find{|key,hash| hash["admin_code"] == doc}[1]["url"]
   end
 
   # This is a bit of a hack to work around the fact that we don't want to change repo names

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -51,14 +51,11 @@ module ResultsHelper
 
   def render_repository_facet_link(doc)
     r = repositories.find{|key,hash| hash["admin_code"] == doc}
-
     if r.nil?
       "missing repository for: #{doc}"
     else
       repository_label r[1]["url"]
     end
-
-#    repository_label repositories.find{|key,hash| hash["admin_code"] == doc}[1]["url"]
   end
 
   # This is a bit of a hack to work around the fact that we don't want to change repo names

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,9 @@ en:
     brooklynhistory:
       home_text: The Center for Brooklyn History collects, preserves, and provides access to the most expansive collection of Brooklyn history and life in the world. The combined collections that comprise the new Center for Brooklyn History's holdings include over 250,000 photographs, 37,000 books, 1,800 archival collections, 2,500 maps and atlases, 5,700 artifacts, 300 paintings, 1,400 oral history interviews, and more. The collections foster new and cutting-edge scholarship, support public learning and research, and enrich CBH's exhibitions, educational activities, and public programming.
       url: http://www.brooklynhistory.org/library/search.html
+    arabartarchive:
+      url: https://nyuad.nyu.edu/en/research/faculty-labs-and-projects/al-mawrid.html
+
   facets:
     help:
       repository: "View materials from one special collection (e.g. Fales Library or New-York Historical Society)."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
       home_text: The Center for Brooklyn History collects, preserves, and provides access to the most expansive collection of Brooklyn history and life in the world. The combined collections that comprise the new Center for Brooklyn History's holdings include over 250,000 photographs, 37,000 books, 1,800 archival collections, 2,500 maps and atlases, 5,700 artifacts, 300 paintings, 1,400 oral history interviews, and more. The collections foster new and cutting-edge scholarship, support public learning and research, and enrich CBH's exhibitions, educational activities, and public programming.
       url: http://www.brooklynhistory.org/library/search.html
     arabartarchive:
+      home_text: The Arab Art Archive works with artists, their families, collections, galleries, arts organizations, and other institutions throughout the region and around the world to digitize a range of documentary material pertaining to the history of modern art in the Arab countries.
       url: https://nyuad.nyu.edu/en/research/faculty-labs-and-projects/al-mawrid.html
 
   facets:

--- a/config/repositories-findingaids_2022_migration.yml
+++ b/config/repositories-findingaids_2022_migration.yml
@@ -4,7 +4,7 @@ Catalog:
       display: 'The Fales Library & Special Collections'
       url_safe_display: 'The Fales Library %26 Special Collections'
       url: "fales"
-      admin_code: fales
+      admin_code: "fales"
     tamiment:
       display: 'Tamiment Library & Wagner Labor Archives'
       url_safe_display: 'Tamiment Library %26 Wagner Labor Archives'
@@ -50,3 +50,8 @@ Catalog:
       url_safe_display: 'Villa La Pietra'
       url: "vlp"
       admin_code: "vlp"
+    arabartarchive:
+      display: 'Arab Art Archive, al Mawrid, NYU Abu Dhabi'
+      url_safe_display: 'Arab Art Archive%2C al Mawrid%2C NYU Abu Dhabi'
+      url: "arabartarchive"
+      admin_code: "arabartarchive"

--- a/config/repositories.yml
+++ b/config/repositories.yml
@@ -50,3 +50,8 @@ Catalog:
       url_safe_display: 'Villa La Pietra'
       url: "vlp"
       admin_code: "vlp"
+    arabartarchive:
+      display: 'Arab Art Archive, al Mawrid, NYU Abu Dhabi'
+      url_safe_display: 'Arab Art Archive%2C al Mawrid%2C NYU Abu Dhabi'
+      url: "arabartarchive"
+      admin_code: "arabartarchive"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -130,6 +130,13 @@ describe ApplicationHelper do
         it { expect(repository['admin_code']).to eql("vlp") }
       end
 
+      context "when repository is arabartarchive" do
+        subject(:repository) { repositories['arabartarchive'] }
+        it { expect(repository['display']).to eql("Arab Art Archive, al Mawrid, NYU Abu Dhabi") }
+        it { expect(repository['url_safe_display']).to eql("Arab Art Archive%2C al Mawrid%2C NYU Abu Dhabi") }
+        it { expect(repository['url']).to eql("arabartarchive") }
+        it { expect(repository['admin_code']).to eql("arabartarchive") }
+      end
     end
   end
 
@@ -161,12 +168,76 @@ describe ApplicationHelper do
         it { expect(repository['admin_code']).to eql("cbh") }
       end
 
-      context "when repository is 'tamiment', nothing should have changed" do
+      context "when repository is Fales" do
+        subject(:repository) { repositories['fales'] }
+        it { expect(repository['display']).to eql("The Fales Library & Special Collections") }
+        it { expect(repository['url_safe_display']).to eql("The Fales Library %26 Special Collections") }
+        it { expect(repository['url']).to eql("fales") }
+        it { expect(repository['admin_code']).to eql("fales") }
+      end
+
+      context "when repository is Tamiment " do
         subject(:repository) { repositories['tamiment'] }
         it { expect(repository['display']).to eql("Tamiment Library & Wagner Labor Archives") }
+        it { expect(repository['url_safe_display']).to eql("Tamiment Library %26 Wagner Labor Archives") }
         it { expect(repository['url']).to eql("tamiment") }
-        it { expect(repository["url_safe_display"]).to eql("Tamiment Library %26 Wagner Labor Archives") }
         it { expect(repository['admin_code']).to eql("tamwag") }
+      end
+
+      context "when repository is NYU Archives " do
+        subject(:repository) { repositories['universityarchives'] }
+        it { expect(repository['display']).to eql("New York University Archives") }
+        it { expect(repository['url_safe_display']).to eql("New York University Archives") }
+        it { expect(repository['url']).to eql("universityarchives") }
+        it { expect(repository['admin_code']).to eql("archives") }
+      end
+
+      context "when repository is NYHS" do
+        subject(:repository) { repositories['nyhistory'] }
+        it { expect(repository['display']).to eql("New-York Historical Society") }
+        it { expect(repository['url_safe_display']).to eql("New-York Historical Society") }
+        it { expect(repository['url']).to eql("nyhistory") }
+        it { expect(repository['admin_code']).to eql("nyhs") }
+      end
+
+      context "when repository is Poly Archives" do
+        subject(:repository) { repositories['poly'] }
+        it { expect(repository['display']).to eql("Poly Archives") }
+        it { expect(repository['url_safe_display']).to eql("Poly Archives") }
+        it { expect(repository['url']).to eql("poly") }
+        it { expect(repository['admin_code']).to eql("poly") }
+      end
+
+      context "when repository is RISM" do
+        subject(:repository) { repositories['rism'] }
+        it { expect(repository['display']).to eql("Research Institute for the Study of Man") }
+        it { expect(repository['url_safe_display']).to eql("Research Institute for the Study of Man") }
+        it { expect(repository['url']).to eql("rism") }
+        it { expect(repository['admin_code']).to eql("rism") }
+      end
+
+      context "when repository is NYUAD" do
+        subject(:repository) { repositories['nyuad'] }
+        it { expect(repository['display']).to eql("NYU Abu Dhabi Archives and Special Collections") }
+        it { expect(repository['url_safe_display']).to eql("NYU Abu Dhabi Archives and Special Collections") }
+        it { expect(repository['url']).to eql("nyuad") }
+        it { expect(repository['admin_code']).to eql("nyuad") }
+      end
+
+      context "when repository is VLP" do
+        subject(:repository) { repositories['vlp'] }
+        it { expect(repository['display']).to eql("Villa La Pietra") }
+        it { expect(repository['url_safe_display']).to eql("Villa La Pietra") }
+        it { expect(repository['url']).to eql("vlp") }
+        it { expect(repository['admin_code']).to eql("vlp") }
+      end
+
+      context "when repository is arabartarchive" do
+        subject(:repository) { repositories['arabartarchive'] }
+        it { expect(repository['display']).to eql("Arab Art Archive, al Mawrid, NYU Abu Dhabi") }
+        it { expect(repository['url_safe_display']).to eql("Arab Art Archive%2C al Mawrid%2C NYU Abu Dhabi") }
+        it { expect(repository['url']).to eql("arabartarchive") }
+        it { expect(repository['admin_code']).to eql("arabartarchive") }
       end
     end
   end

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -197,10 +197,18 @@ describe ResultsHelper do
   end
 
   describe "#render_repository_facet_link" do
-    subject { helper.render_repository_facet_link(document[:document][:repository_ssi]) }
-    let(:repositories) {{"fales" => {"display" => "The Fales Library", "admin_code" => "fales", "url" => "fales"}}}
-    before { allow(helper).to receive(:repositories).and_return repositories }
-    it { is_expected.to eql "The Fales Library" }
+    context "when the repository is found" do
+      subject { helper.render_repository_facet_link(document[:document][:repository_ssi]) }
+      let(:repositories) {{"fales" => {"display" => "The Fales Library", "admin_code" => "fales", "url" => "fales"}}}
+      before { allow(helper).to receive(:repositories).and_return repositories }
+      it { is_expected.to eql "The Fales Library" }
+    end
+    context "when the repository is not found" do
+      subject { helper.render_repository_facet_link("foobar") }
+      let(:repositories) {{"fales" => {"display" => "The Fales Library", "admin_code" => "fales", "url" => "fales"}}}
+      before { allow(helper).to receive(:repositories).and_return repositories }
+      it { is_expected.to eql "missing repository for: foobar" }
+    end
   end
 
   describe "#render_repository_link" do


### PR DESCRIPTION
## Overview

This PR...
1.) adds the `arabartarchive` archival repository to the FAB
2.) provides a default string if a repository lookup fails in `#render_repository_facet_link`
3.) updates `GETTING_STARTED.md` with instructions for adding a new archival repository