### PR TITLE
app/assets/stylesheets/findingaids.css.scss: remove obsolete CSS temporary workaround for fixing "Online Access" in Digital Content facet

### DIFF
--- a/app/assets/stylesheets/findingaids.css.scss
+++ b/app/assets/stylesheets/findingaids.css.scss
@@ -235,34 +235,6 @@ dd.blacklight-collection_ssm{
   }
 }
 
-// begin hack: overwrite buggy values from solr
-// thanks to https://stackoverflow.com/questions/7896402/how-can-i-replace-text-with-css
-// link element can't use font-size: 0 solution since it removes functionality; for non-interactive elements, this works best
-#facet-dao_sim .facet_select {
-  text-indent: -9999px;
-  line-height: 0;
-  display: block;
-}
-#facet-dao_sim .facet_select:after {
-  content: "Online Access";
-  text-indent: 0;
-  display: block;
-  line-height: initial;
-}
-#facet-dao_sim .facet-label .selected, .appliedFilter.filter-dao_sim .filterValue {
-  font-size: 0;
-}
-#facet-dao_sim .facet-label .selected:after {
-  content: "Online Access";
-  font-size: 14px;
-}
-.appliedFilter.filter-dao_sim .filterValue:after {
-  content: "Online Access";
-  font-size: 13px;
-}
-// end hack
-
-
 // Add always visible underline for links in main content area
 #main .col-sm-7 a,
 #main #sidebar a, footer a {


### PR DESCRIPTION
Jira: [FAB: Remove DLFA\-175 CSS workaround for fixing the old "translation missing" bug](https://nyu.atlassian.net/browse/DLFA-325)

This temporary workaround is messing with [FAB: revisit "digital content > available online" facet](https://nyu.atlassian.net/browse/DLFA-260).